### PR TITLE
Add resultsDir env var and summaries VIEW

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -26,6 +26,22 @@ create table public.benchmarks (
   inserted_at   timestamp with time zone    default timezone('utc'::text, now()) not null
 );
 comment on table public.benchmarks is 'Table to store benchmarking data';
+
+-- BENCHMARKING SUMMARIES
+create or replace view benchmark_summaries as (
+  select
+    id
+  , benchmark_name
+  , data->'metrics'->'http_reqs'->'rate' as http_reqs_rate
+  , data->'metrics'->'http_reqs'->'count' as http_reqs_count
+  , data->'metrics'->'http_req_duration'->'avg' as http_req_duration_avg
+  , pg_size_pretty((data->'metrics'->'data_received'->'count')::bigint) as data_received
+  , pg_size_pretty((data->'metrics'->'data_sent'->'count')::bigint) as data_sent
+  , data->'metrics'->'vus'->'value' as vus
+  , data->'metrics'->'failed requests'->'value' as failed_requests
+  from
+  benchmarks
+);
 ```
 
 Export the following environment variables before running the scripts

--- a/supabase/write-results-db.js
+++ b/supabase/write-results-db.js
@@ -4,6 +4,8 @@ const { createClient } = require('@supabase/supabase-js')
 
 const { supabaseKey, supabaseUrl } = process.env
 
+const resultsDir = process.env.resultsDir || './output';
+
 if (!supabaseKey || !supabaseUrl) {
   console.log('Export supabaseKey and supabaseUrl as environment variables. Exiting.')
   process.exit(0)
@@ -12,13 +14,13 @@ if (!supabaseKey || !supabaseUrl) {
 const supabase = createClient(supabaseUrl, supabaseKey)
 
 ;(async () => {
-  const files = await fs.readdir('./output/')
+  const files = await fs.readdir(resultsDir)
 
   for (const file of files) {
     if (file.endsWith('.json')) {
       // valid benchmark file, lets update supabase table
       const benchmarkName = file.split('.json')[0]
-      const data = JSON.parse(await fs.readFile(`./output/${file}`))
+      const data = JSON.parse(await fs.readFile(`${resultsDir}/${file}`))
 
       try {
         await supabase.from('benchmarks').insert([{ data, benchmark_name: benchmarkName }])


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Add resultsDir env var to the  `write-results-db.js` script to specify a dir different than `./output` - this helps with uploading the postgrest benchmark results to a supabase project.
- Added a sql VIEW for getting benchmark summaries - using this for the results on https://github.com/supabase/benchmarks/issues/2#issuecomment-700051893. The format is like the one on the attachment. This might help with the KPS benchmark as well.

![2020-09-29-181916_1273x204_scrot](https://user-images.githubusercontent.com/1829294/94626983-e8850300-0281-11eb-9793-43684802f6b6.png)
