### PR TITLE
postgrest: add RPC load tests and config for testing on t3a.nano..t3a.xlarge..c5.xlarge 

### DIFF
--- a/postgrest/deploy.nix
+++ b/postgrest/deploy.nix
@@ -98,22 +98,6 @@ in {
     };
   };
 
-  # Configuration
-  t2nano = {resources, ...}: {
-    deployment = {
-      targetEnv = "ec2";
-      ec2 = {
-        inherit region accessKeyId;
-        instanceType             = "t2.nano";
-        associatePublicIpAddress = true;
-        ebsInitialRootDiskSize   = 10;
-        keyPair                  = resources.ec2KeyPairs.pgrstBenchKeyPair;
-        subnetId                 = resources.vpcSubnets.pgrstBenchSubnet;
-        securityGroupIds         = [resources.ec2SecurityGroups.pgrstBenchSecGroup.name];
-      };
-    };
-  } // serverConf;
-
   t3anano = {resources, ...}: {
     deployment = {
       targetEnv = "ec2";
@@ -128,6 +112,85 @@ in {
       };
     };
     boot.loader.grub.device = pkgs.lib.mkForce "/dev/nvme0n1"; # Fix for https://github.com/NixOS/nixpkgs/issues/62824#issuecomment-516369379
+  } // serverConf;
+
+  t3amicro = {resources, ...}: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "t3a.micro";
+        associatePublicIpAddress = true;
+        ebsInitialRootDiskSize   = 10;
+        keyPair                  = resources.ec2KeyPairs.pgrstBenchKeyPair;
+        subnetId                 = resources.vpcSubnets.pgrstBenchSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.pgrstBenchSecGroup.name];
+      };
+    };
+    boot.loader.grub.device = pkgs.lib.mkForce "/dev/nvme0n1"; # Fix for https://github.com/NixOS/nixpkgs/issues/62824#issuecomment-516369379
+  } // serverConf;
+
+  t3amedium = {resources, ...}: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "t3a.medium";
+        associatePublicIpAddress = true;
+        ebsInitialRootDiskSize   = 10;
+        keyPair                  = resources.ec2KeyPairs.pgrstBenchKeyPair;
+        subnetId                 = resources.vpcSubnets.pgrstBenchSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.pgrstBenchSecGroup.name];
+      };
+    };
+    boot.loader.grub.device = pkgs.lib.mkForce "/dev/nvme0n1"; # Fix for https://github.com/NixOS/nixpkgs/issues/62824#issuecomment-516369379
+  } // serverConf;
+
+  t3alarge = {resources, ...}: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "t3a.large";
+        associatePublicIpAddress = true;
+        ebsInitialRootDiskSize   = 10;
+        keyPair                  = resources.ec2KeyPairs.pgrstBenchKeyPair;
+        subnetId                 = resources.vpcSubnets.pgrstBenchSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.pgrstBenchSecGroup.name];
+      };
+    };
+    boot.loader.grub.device = pkgs.lib.mkForce "/dev/nvme0n1";
+  } // serverConf;
+
+  t3axlarge = {resources, ...}: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "t3a.xlarge";
+        associatePublicIpAddress = true;
+        ebsInitialRootDiskSize   = 10;
+        keyPair                  = resources.ec2KeyPairs.pgrstBenchKeyPair;
+        subnetId                 = resources.vpcSubnets.pgrstBenchSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.pgrstBenchSecGroup.name];
+      };
+    };
+    boot.loader.grub.device = pkgs.lib.mkForce "/dev/nvme0n1";
+  } // serverConf;
+
+  c5xlarge = {resources, ...}: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "c5.xlarge";
+        associatePublicIpAddress = true;
+        ebsInitialRootDiskSize   = 10;
+        keyPair                  = resources.ec2KeyPairs.pgrstBenchKeyPair;
+        subnetId                 = resources.vpcSubnets.pgrstBenchSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.pgrstBenchSecGroup.name];
+      };
+    };
   } // serverConf;
 
   client = {nodes, resources, ...}: {
@@ -152,9 +215,13 @@ in {
       { domain = "root"; type = "hard"; item = "nofile"; value = "5000"; }
       { domain = "root"; type = "soft"; item = "nofile"; value = "5000"; }
     ];
-    networking.hosts ={
-      "${nodes.t2nano.config.networking.privateIPv4}"  = [ "t2nano" ];
-      "${nodes.t3anano.config.networking.privateIPv4}" = [ "t3anano" ];
+    networking.hosts = {
+      "${nodes.t3anano.config.networking.privateIPv4}"   = [ "t3anano" ];
+      "${nodes.t3amicro.config.networking.privateIPv4}"  = [ "t3amicro" ];
+      "${nodes.t3amedium.config.networking.privateIPv4}" = [ "t3amedium" ];
+      "${nodes.t3alarge.config.networking.privateIPv4}"  = [ "t3alarge" ];
+      "${nodes.t3axlarge.config.networking.privateIPv4}" = [ "t3axlarge" ];
+      "${nodes.c5xlarge.config.networking.privateIPv4}"  = [ "c5xlarge" ];
     };
   };
 }

--- a/postgrest/k6/GETAllEmbed.js
+++ b/postgrest/k6/GETAllEmbed.js
@@ -4,7 +4,28 @@ import http from 'k6/http';
 
 const URL = "http://" + __ENV.HOST;
 
-const RATE = (__ENV.HOST == 't2nano')? 40: 40;
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 70;
+      case 't3axlarge': return 55;
+      case 't3alarge':  return 40;
+      case 't3amedium': return 40;
+      case 't3amicro':  return 40;
+      case 't3anano':   return 40;
+      default:          return 40;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 70;
+      case 't3axlarge': return 65;
+      case 't3alarge':  return 40;
+      case 't3amedium': return 40;
+      case 't3amicro':  return 40;
+      case 't3anano':   return 40;
+      default:          return 40;
+    }
+})();
 
 export let options = {
   discardResponseBodies: true,
@@ -13,7 +34,7 @@ export let options = {
       executor: 'constant-arrival-rate',
       rate: RATE,
       timeUnit: '1s',
-      duration: '1m',
+      duration: '30s',
       preAllocatedVUs: 100,
       maxVUs: 600,
     }

--- a/postgrest/k6/GETSingle.js
+++ b/postgrest/k6/GETSingle.js
@@ -4,7 +4,28 @@ import http from 'k6/http';
 
 const URL = "http://" + __ENV.HOST;
 
-const RATE = (__ENV.HOST == 't2nano')? 1100: 1400;
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 2400;
+      case 't3axlarge': return 1600;
+      case 't3alarge':  return 1400;
+      case 't3amedium': return 1400;
+      case 't3amicro':  return 1400;
+      case 't3anano':   return 1400;
+      default:          return 1000;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 3000;
+      case 't3axlarge': return 2300;
+      case 't3alarge':  return 2100;
+      case 't3amedium': return 2100;
+      case 't3amicro':  return 2100;
+      case 't3anano':   return 2100;
+      default:          return 1000;
+    }
+})();
 
 export let options = {
   discardResponseBodies: true,
@@ -13,7 +34,7 @@ export let options = {
       executor: 'constant-arrival-rate',
       rate: RATE,
       timeUnit: '1s',
-      duration: '1m',
+      duration: '30s',
       preAllocatedVUs: 100,
       maxVUs: 600,
     }

--- a/postgrest/k6/GETSingleEmbed.js
+++ b/postgrest/k6/GETSingleEmbed.js
@@ -4,7 +4,28 @@ import http from 'k6/http';
 
 const URL = "http://" + __ENV.HOST;
 
-const RATE = (__ENV.HOST == 't2nano')? 500: 700;
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 1050;
+      case 't3axlarge': return 800;
+      case 't3alarge':  return 500;
+      case 't3amedium': return 500;
+      case 't3amicro':  return 500;
+      case 't3anano':   return 500;
+      default:          return 500;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 1550;
+      case 't3axlarge': return 1200;
+      case 't3alarge':  return 810;
+      case 't3amedium': return 810;
+      case 't3amicro':  return 810;
+      case 't3anano':   return 810;
+      default:          return 500;
+    }
+})();
 
 export let options = {
   discardResponseBodies: true,
@@ -13,7 +34,7 @@ export let options = {
       executor: 'constant-arrival-rate',
       rate: RATE,
       timeUnit: '1s',
-      duration: '1m',
+      duration: '30s',
       preAllocatedVUs: 100,
       maxVUs: 600,
     }

--- a/postgrest/k6/POSTBulk.js
+++ b/postgrest/k6/POSTBulk.js
@@ -4,7 +4,28 @@ import http from 'k6/http';
 
 const URL = "http://" + __ENV.HOST;
 
-const RATE = (__ENV.HOST === 't2nano')? 600: 600;
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 700;
+      case 't3axlarge': return 600;
+      case 't3alarge':  return 600;
+      case 't3amedium': return 600;
+      case 't3amicro':  return 600;
+      case 't3anano':   return 600;
+      default:          return 500;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 700;
+      case 't3axlarge': return 700;
+      case 't3alarge':  return 700;
+      case 't3amedium': return 700;
+      case 't3amicro':  return 700;
+      case 't3anano':   return 700;
+      default:          return 500;
+    }
+})();
 
 export let options = {
   discardResponseBodies: true,
@@ -13,7 +34,7 @@ export let options = {
       executor: 'constant-arrival-rate',
       rate: RATE,
       timeUnit: '1s',
-      duration: '1m',
+      duration: '30s',
       preAllocatedVUs: 100,
       maxVUs: 600,
     }

--- a/postgrest/k6/POSTSingle.js
+++ b/postgrest/k6/POSTSingle.js
@@ -4,7 +4,28 @@ import http from 'k6/http';
 
 const URL = "http://" + __ENV.HOST;
 
-const RATE = (__ENV.HOST === 't2nano')? 1000: 1300;
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 1500;
+      case 't3axlarge': return 1300;
+      case 't3alarge':  return 1300;
+      case 't3amedium': return 1300;
+      case 't3amicro':  return 1300;
+      case 't3anano':   return 1300;
+      default:          return 1000;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 1600;
+      case 't3axlarge': return 1600;
+      case 't3alarge':  return 1600;
+      case 't3amedium': return 1600;
+      case 't3amicro':  return 1600;
+      case 't3anano':   return 1600;
+      default:          return 1000;
+    }
+})();
 
 export let options = {
   discardResponseBodies: true,
@@ -13,7 +34,7 @@ export let options = {
       executor: 'constant-arrival-rate',
       rate: RATE,
       timeUnit: '1s',
-      duration: '1m',
+      duration: '30s',
       preAllocatedVUs: 100,
       maxVUs: 600,
     }

--- a/postgrest/k6/RPCGETSingle.js
+++ b/postgrest/k6/RPCGETSingle.js
@@ -1,0 +1,47 @@
+import { Rate } from "k6/metrics";
+import { check, group, sleep } from 'k6';
+import http from 'k6/http';
+
+const URL = "http://" + __ENV.HOST;
+
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 2400;
+      case 't3axlarge': return 1600;
+      case 't3anano':   return 1500;
+      default:          return 1000;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 3000;
+      case 't3axlarge': return 2300;
+      case 't3anano':   return 2200;
+      default:          return 1000;
+    }
+})();
+
+export let options = {
+  discardResponseBodies: true,
+  scenarios: {
+    constant_request_rate: {
+      executor: 'constant-arrival-rate',
+      rate: RATE,
+      timeUnit: '1s',
+      duration: '30s',
+      preAllocatedVUs: 100,
+      maxVUs: 600,
+    }
+  },
+  thresholds: {
+    'failed requests': ['rate<0.1'],
+    'http_req_duration': ['p(95)<1000']
+  }
+};
+
+const myFailRate = new Rate('failed requests');
+
+export default function() {
+  let res = http.get(URL + "/rpc/ret_artists?select=*&artist_id=eq.3");
+  myFailRate.add(res.status !== 200);
+}

--- a/postgrest/k6/RPCGETSingleEmbed.js
+++ b/postgrest/k6/RPCGETSingleEmbed.js
@@ -1,0 +1,47 @@
+import { Rate } from "k6/metrics";
+import { check, group, sleep } from 'k6';
+import http from 'k6/http';
+
+const URL = "http://" + __ENV.HOST;
+
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 1100;
+      case 't3axlarge': return 850;
+      case 't3anano':   return 600;
+      default:          return 1000;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 1500;
+      case 't3axlarge': return 1200;
+      case 't3anano':   return 800;
+      default:          return 1000;
+    }
+})();
+
+export let options = {
+  discardResponseBodies: true,
+  scenarios: {
+    constant_request_rate: {
+      executor: 'constant-arrival-rate',
+      rate: RATE,
+      timeUnit: '1s',
+      duration: '30s',
+      preAllocatedVUs: 100,
+      maxVUs: 600,
+    }
+  },
+  thresholds: {
+    'failed requests': ['rate<0.1'],
+    'http_req_duration': ['p(95)<1000']
+  }
+};
+
+const myFailRate = new Rate('failed requests');
+
+export default function() {
+  let res = http.get(URL + "/rpc/ret_albums?select=album_id,title,artist_id,track(*,genre(*))&artist_id=eq.127");
+  myFailRate.add(res.status !== 200);
+}

--- a/postgrest/k6/RPCSimple.js
+++ b/postgrest/k6/RPCSimple.js
@@ -1,0 +1,47 @@
+import { Rate } from "k6/metrics";
+import { check, group, sleep } from 'k6';
+import http from 'k6/http';
+
+const URL = "http://" + __ENV.HOST;
+
+const RATE = (function(){
+  if(__ENV.VERSION == 'v701'){
+    switch(__ENV.HOST){
+      case 'c5xlarge':  return 2400;
+      case 't3axlarge': return 1600;
+      case 't3anano':   return 1600;
+      default:          return 1500;
+    }
+  }
+  else switch(__ENV.HOST){
+      case 'c5xlarge':  return 3000;
+      case 't3axlarge': return 2200;
+      case 't3anano':   return 2100;
+      default:          return 1000;
+    }
+})();
+
+export let options = {
+  discardResponseBodies: true,
+  scenarios: {
+    constant_request_rate: {
+      executor: 'constant-arrival-rate',
+      rate: RATE,
+      timeUnit: '1s',
+      duration: '30s',
+      preAllocatedVUs: 100,
+      maxVUs: 600,
+    }
+  },
+  thresholds: {
+    'failed requests': ['rate<0.1'],
+    'http_req_duration': ['p(95)<1000']
+  }
+};
+
+const myFailRate = new Rate('failed requests');
+
+export default function() {
+  let res = http.get(URL + "/rpc/add_them?a=1&b=2&c=3&d=4&e=5");
+  myFailRate.add(res.status !== 200);
+}

--- a/postgrest/sql/chinook.sql
+++ b/postgrest/sql/chinook.sql
@@ -18,6 +18,7 @@
    Modified for postgrest-benchmark:
    Summary of Changes:
      - Removed employee table indexes and constraints
+     - Added add_them, ret_albums and ret_artists functions
 ********************************************************************************/
 
 
@@ -23861,3 +23862,15 @@ ALTER TABLE "film_actor" ADD PRIMARY KEY ("actor_id", "film_id");
 alter table employee drop constraint pk_employee cascade;
 drop index ifk_employee_reports_to;
 drop sequence employee_employee_id_seq cascade;
+
+create or replace function ret_albums() returns setof album as $$
+  select * from album
+$$ language sql stable;
+
+create or replace function ret_artists() returns setof artist as $$
+  select * from artist
+$$ language sql stable;
+
+create or replace function add_them(a int, b int, c int, d int, e int) returns int as $$
+  select a + b + c + d + e;
+$$ language sql immutable;


### PR DESCRIPTION
Adds the k6 scripts and nix config used for the latest progress on the benchmark being discussed on https://github.com/supabase/benchmarks/issues/2.