### PR TITLE
postgrest: add randomized ids for GET tests

### DIFF
--- a/postgrest/k6/GETSingle.js
+++ b/postgrest/k6/GETSingle.js
@@ -48,6 +48,7 @@ export let options = {
 const myFailRate = new Rate('failed requests');
 
 export default function() {
-  let res = http.get(URL + "/artist?select=*&artist_id=eq.3");
+  let id =  Math.floor((Math.random() * 275) + 1);
+  let res = http.get(URL + "/artist?select=*&artist_id=eq." + id);
   myFailRate.add(res.status !== 200);
 }

--- a/postgrest/k6/GETSingleEmbed.js
+++ b/postgrest/k6/GETSingleEmbed.js
@@ -48,6 +48,7 @@ export let options = {
 const myFailRate = new Rate('failed requests');
 
 export default function() {
-  let res = http.get(URL + "/album?select=*,track(*,genre(*))&artist_id=eq.127");
+  let id =  Math.floor((Math.random() * 347) + 1);
+  let res = http.get(URL + "/album?select=*,track(*,genre(*))&artist_id=eq." + id);
   myFailRate.add(res.status !== 200);
 }

--- a/postgrest/k6/RPCGETSingle.js
+++ b/postgrest/k6/RPCGETSingle.js
@@ -42,6 +42,7 @@ export let options = {
 const myFailRate = new Rate('failed requests');
 
 export default function() {
-  let res = http.get(URL + "/rpc/ret_artists?select=*&artist_id=eq.3");
+  let id =  Math.floor((Math.random() * 275) + 1);
+  let res = http.get(URL + "/rpc/ret_artists?select=*&artist_id=eq." + id);
   myFailRate.add(res.status !== 200);
 }

--- a/postgrest/k6/RPCGETSingleEmbed.js
+++ b/postgrest/k6/RPCGETSingleEmbed.js
@@ -42,6 +42,7 @@ export let options = {
 const myFailRate = new Rate('failed requests');
 
 export default function() {
-  let res = http.get(URL + "/rpc/ret_albums?select=album_id,title,artist_id,track(*,genre(*))&artist_id=eq.127");
+  let id =  Math.floor((Math.random() * 347) + 1);
+  let res = http.get(URL + "/rpc/ret_albums?select=album_id,title,artist_id,track(*,genre(*))&artist_id=eq." + id);
   myFailRate.add(res.status !== 200);
 }


### PR DESCRIPTION
Adds random ids for the PostgREST load tests. I didn't find any significant change on the benchmark results, which makes sense since the ids are indexed.