### PR TITLE
postgrest: try to find best db-pool value for reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Infrastucture benchmarks at Supabase.
 ├── postgrest               # PostgREST benchmark tests/code
 ├── realtime                # Realtime benchmark tests/code
 ├── supabase                # Supabase (full system) benchmark tests/code
-└── migrations              # Database migrations. All results are stored in a Supabase database  
+└── migrations              # Database migrations. All results are stored in a Supabase database
 ```
 

--- a/postgrest/README.md
+++ b/postgrest/README.md
@@ -27,7 +27,7 @@ pgrbench-deploy
 To explore and connect to the ec2 instances:
 
 ```
-pgrbench-ssh t3anano
+pgrbench-ssh pgrstServer
 
 # psql -U postgres
 # \d
@@ -65,27 +65,53 @@ pgrbench-k6 t3anano k6/GETSingle.js
 To load test with nginx included do:
 
 ```bash
-export PGRBENCH_SETUP=with-nginx
+export PGRBENCH_SETUP="with-nginx"
 pgrbench-deploy
 ```
 
-Also to test nginx with a better config(unix socket + keepalive)
+## Unix socket(default)
+
+To load test connecting pgrest to pg with unix socket, and pgrest to nginx with unix socket.
 
 ```bash
-export PGRBENCH_SETUP=with-nginx-best-config
+export PGRBENCH_CONN_TYPE="unix-socket"
 pgrbench-deploy
 ```
 
-Then run the k6 tests the same as above.
+To use tcp instead, you can do:
 
-## Notes
+```bash
+export PGRBENCH_CONN_TYPE="tcp"
+pgrbench-deploy
+```
 
-- Scenarios to test:
-  - [x]read heavy workload(with resource embedding)
-  - [x]write heavy workload(with and without [specifying-columns](http://postgrest.org/en/v7.0.0/api.html#specifying-columns))
-  - [ ]pg + pgrest on the same machine(unix socket and tcp).
-  - [ ]pg and pgrest on different machines?
-  - [ ]pgrest with `pre-request`?
+## Separate PostgreSQL
+
+To load test with a pg on a different ec2 instance.
+
+```bash
+export PGRBENCH_SEPARATE_PG="true"
+pgrbench-deploy
+```
+
+To change its EC2 instance type(t3a.nano by default):
+
+```bash
+export PGRBENCH_PG_INSTANCE_TYPE="t3a.xlarge"
+pgrbench-deploy
+```
+
+## Scenarios to test
+
+- [x]read heavy workload(with resource embedding)
+- [x]write heavy workload
+- [x]pg + pgrest on the same ec2 instance(unix socket and tcp).
+- [x]pg + pgrest + nginx on the same ec2 instance
+- [x]pg and pgrest(w/o nginx) on separate ec2 instance
+- [x]separate pg with different type of ec2 instances and tuned with https://pgtune.leopard.in.ua/#/
+- [ ]pgrest with `pre-request`
+- [ ]insertions with [specifying-columns](http://postgrest.org/en/v7.0.0/api.html#specifying-columns)
+- [ ]a slow rpc with `pg_sleep`
 
 ## Other benchmarks
 

--- a/postgrest/k6/GETAllEmbed.js
+++ b/postgrest/k6/GETAllEmbed.js
@@ -2,43 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 70;
-      case 't3axlarge': return 55;
-      case 't3alarge':  return 40;
-      case 't3amedium': return 40;
-      case 't3amicro':  return 40;
-      case 't3anano':   return 40;
-      default:          return 40;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 70;
-      case 't3axlarge': return 65;
-      case 't3alarge':  return 40;
-      case 't3amedium': return 40;
-      case 't3amicro':  return 40;
-      case 't3anano':   return 40;
-      default:          return 40;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/GETSingle.js
+++ b/postgrest/k6/GETSingle.js
@@ -2,44 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  //TODO: remove conditionals
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 2400;
-      case 't3axlarge': return 1600;
-      case 't3alarge':  return 1400;
-      case 't3amedium': return 1400;
-      case 't3amicro':  return 1400;
-      case 't3anano':   return 1400;
-      default:          return 1000;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 3000;
-      case 't3axlarge': return 2300;
-      case 't3alarge':  return 2100;
-      case 't3amedium': return 2100;
-      case 't3amicro':  return 2100;
-      case 't3anano':   return 2100;
-      default:          return 1000;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/GETSingle.js
+++ b/postgrest/k6/GETSingle.js
@@ -2,17 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const NGINX_PREFIX = __ENV.PGRBENCH_SETUP.startsWith("with-nginx")?"/api":"";
-
-const URL = "http://" + __ENV.HOST + NGINX_PREFIX;
+const URL = "http://" + __ENV.HOST;
 
 const RATE = (function(){
   //TODO: remove conditionals
-  if(__ENV.PGRBENCH_SETUP == "with-nginx")
-    return 1450;
-  else if(__ENV.PGRBENCH_SETUP == "with-nginx-best-config")
-    return 1800;
-  else if(__ENV.VERSION == 'v701'){
+  if(__ENV.VERSION == 'v701'){
     switch(__ENV.HOST){
       case 'c5xlarge':  return 2400;
       case 't3axlarge': return 1600;

--- a/postgrest/k6/GETSingleEmbed.js
+++ b/postgrest/k6/GETSingleEmbed.js
@@ -2,43 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 1050;
-      case 't3axlarge': return 800;
-      case 't3alarge':  return 500;
-      case 't3amedium': return 500;
-      case 't3amicro':  return 500;
-      case 't3anano':   return 500;
-      default:          return 500;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 1550;
-      case 't3axlarge': return 1200;
-      case 't3alarge':  return 810;
-      case 't3amedium': return 810;
-      case 't3amicro':  return 810;
-      case 't3anano':   return 810;
-      default:          return 500;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/PATCHSingle.js
+++ b/postgrest/k6/PATCHSingle.js
@@ -1,29 +1,11 @@
 import http from 'k6/http'
 import { Rate } from 'k6/metrics'
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  switch(__ENV.HOST){
-    case 'c5xlarge':  return 1650;
-    case 't3axlarge': return 1500;
-    case 't3anano':   return 1500;
-    default:          return 1000;
-  }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/POSTBulk.js
+++ b/postgrest/k6/POSTBulk.js
@@ -2,43 +2,11 @@ import { Rate, Gauge } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 700;
-      case 't3axlarge': return 600;
-      case 't3alarge':  return 600;
-      case 't3amedium': return 600;
-      case 't3amicro':  return 600;
-      case 't3anano':   return 600;
-      default:          return 500;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 700;
-      case 't3axlarge': return 700;
-      case 't3alarge':  return 700;
-      case 't3amedium': return 700;
-      case 't3amicro':  return 700;
-      case 't3anano':   return 700;
-      default:          return 500;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/POSTSingle.js
+++ b/postgrest/k6/POSTSingle.js
@@ -2,16 +2,10 @@ import { Rate, Gauge } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const NGINX_PREFIX = __ENV.PGRBENCH_SETUP.startsWith("with-nginx")?"/api":"";
-
-const URL = "http://" + __ENV.HOST + NGINX_PREFIX;
+const URL = "http://" + __ENV.HOST;
 
 const RATE = (function(){
-  if(__ENV.PGRBENCH_SETUP == "with-nginx")
-    return 1200;
-  else if(__ENV.PGRBENCH_SETUP == "with-nginx-best-config")
-    return 1450;
-  else if(__ENV.VERSION == 'v701'){
+  if(__ENV.VERSION == 'v701'){
     switch(__ENV.HOST){
       case 'c5xlarge':  return 1500;
       case 't3axlarge': return 1300;

--- a/postgrest/k6/POSTSingle.js
+++ b/postgrest/k6/POSTSingle.js
@@ -2,43 +2,11 @@ import { Rate, Gauge } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 1500;
-      case 't3axlarge': return 1300;
-      case 't3alarge':  return 1300;
-      case 't3amedium': return 1300;
-      case 't3amicro':  return 1300;
-      case 't3anano':   return 1300;
-      default:          return 1000;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 1600;
-      case 't3axlarge': return 1600;
-      case 't3alarge':  return 1600;
-      case 't3amedium': return 1600;
-      case 't3amicro':  return 1600;
-      case 't3anano':   return 1600;
-      default:          return 1000;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/RPCGETSingle.js
+++ b/postgrest/k6/RPCGETSingle.js
@@ -2,37 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 2400;
-      case 't3axlarge': return 1600;
-      case 't3anano':   return 1500;
-      default:          return 1000;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 3000;
-      case 't3axlarge': return 2300;
-      case 't3anano':   return 2200;
-      default:          return 1000;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/RPCGETSingleEmbed.js
+++ b/postgrest/k6/RPCGETSingleEmbed.js
@@ -2,37 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 1100;
-      case 't3axlarge': return 850;
-      case 't3anano':   return 600;
-      default:          return 1000;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 1500;
-      case 't3axlarge': return 1200;
-      case 't3anano':   return 800;
-      default:          return 1000;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/RPCSimple.js
+++ b/postgrest/k6/RPCSimple.js
@@ -2,37 +2,11 @@ import { Rate } from "k6/metrics";
 import { check, group, sleep } from 'k6';
 import http from 'k6/http';
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  if(__ENV.VERSION == 'v701'){
-    switch(__ENV.HOST){
-      case 'c5xlarge':  return 2400;
-      case 't3axlarge': return 1600;
-      case 't3anano':   return 1600;
-      default:          return 1500;
-    }
-  }
-  else switch(__ENV.HOST){
-      case 'c5xlarge':  return 3000;
-      case 't3axlarge': return 2200;
-      case 't3anano':   return 2100;
-      default:          return 1000;
-    }
-})();
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/k6/RPCSimple.js
+++ b/postgrest/k6/RPCSimple.js
@@ -42,6 +42,7 @@ export let options = {
 const myFailRate = new Rate('failed requests');
 
 export default function() {
-  let res = http.get(URL + "/rpc/add_them?a=1&b=2&c=3&d=4&e=5");
+  let num =  Math.floor((Math.random() * 347) + 1);
+  let res = http.get(URL + `/rpc/add_them?a=${num}&b=${num+1}&c=${num+2}&d=${num+3}&e=${num+4}`);
   myFailRate.add(res.status !== 200);
 }

--- a/postgrest/k6/ReadSchemaPATCHSingle.js
+++ b/postgrest/k6/ReadSchemaPATCHSingle.js
@@ -4,33 +4,11 @@
 import http from 'k6/http'
 import { Rate } from 'k6/metrics'
 
-const URL = "http://" + __ENV.HOST;
+const URL = "http://pgrst";
 
-const RATE = (function(){
-  switch(__ENV.HOST){
-    case 't3axlarge': return 1300;
-    case 't3alarge': return 950;
-    case 't3asmall': return 750;
-    case 't3amicro': return 350;
-    case 't3anano':  return 150;
-    default:         return 150;
-  }
-})();
-
-const myFailRate = new Rate('failed requests')
-
-export let options = {
-  discardResponseBodies: true,
-  scenarios: {
-    constant_request_rate: {
-      executor: 'constant-arrival-rate',
-      rate: RATE,
-      timeUnit: '1s',
-      duration: '30s',
-      preAllocatedVUs: 100,
-      maxVUs: 600,
-    }
-  },
+export const options = {
+  vus: 10,
+  duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],
     'http_req_duration': ['p(95)<1000']

--- a/postgrest/pgrst.nix
+++ b/postgrest/pgrst.nix
@@ -1,15 +1,10 @@
-{ stdenv, fetchurl, isNightly }:
+{ stdenv, fetchurl }:
 
 stdenv.mkDerivation {
   name = "postgrest";
-  src = if isNightly
-    then fetchurl {
-      url = "https://github.com/PostgREST/postgrest/releases/download/nightly/postgrest-nightly-2020-12-09-14-20-ebd474a-linux-x64-static.tar.xz";
-      sha256 = "17si275mjc0mzz7zr9pl05bzg8h7xkrpvnfsf563bkwngyla7cqk";
-    }
-    else fetchurl {
-      url = "https://github.com/PostgREST/postgrest/releases/download/v7.0.1/postgrest-v7.0.1-linux-x64-static.tar.xz";
-      sha256 = "0h5zlpz7f7x220pklp28pggkpai7vfv06dpdal4xpq8bc56gf27p";
+  src = fetchurl {
+      url = "https://github.com/PostgREST/postgrest/releases/download/v9.0.0/postgrest-v9.0.0-linux-static-x64.tar.xz";
+      sha256 = "0gngjj7bc93v9dzyxxlmqiza2p3dm8w5vp6wf26vlmwm2zm22j7a";
     };
   phases = ["installPhase" "patchPhase"];
   installPhase = ''

--- a/postgrest/shell.nix
+++ b/postgrest/shell.nix
@@ -67,6 +67,6 @@ pkgs.mkShell {
   shellHook = ''
     export NIX_PATH="nixpkgs=${nixpkgs}:."
     export NIXOPS_STATE=".deployment.nixops"
-    export PGRST_VER="nightly"
+    export PGRBENCH_CONN_TYPE="unix-socket"
   '';
 }

--- a/postgrest/shell.nix
+++ b/postgrest/shell.nix
@@ -32,9 +32,9 @@ let
     pkgs.writeShellScriptBin "pgrbench-k6"
       ''
         set -euo pipefail
-        filename=$1$(basename $2 .js)
+        filename=$(basename $1 .js)
 
-        nixops ssh -d pgrbench client k6 run --summary-export=$filename.json -e HOST=$1 - < $2
+        nixops ssh -d pgrbench client k6 run --summary-export=$filename.json - < $1
       '';
   ssh =
     pkgs.writeShellScriptBin "pgrbench-ssh"


### PR DESCRIPTION
Setup for attempting to find the best `db-pool` value on different EC2 instance types (`t3a.nano`, `t3a.xlarge`, `t3a.2xlarge`), with a PostgreSQL tuned according to https://pgtune.leopard.in.ua.

I've found that `db-pool=20` is good as a default for all instances since it leads to slightly increased reads when load tested under 20 VUs.

I haven't been able to find an improvement when increasing `db-pool` despite having a PostgreSQL instance with more vCPUs(2, 4 and 8) and trying different k6 VU values(10, 20, 30 .. 250). It's possible that k6 - on a single `t3a.xlarge` instance - is not able to generate enough load for `db-pool` to matter. Will try a different load test setup(more client instances or a different tool) on a later PR.

#### Results for GETSingle on a t3a.nano

- `db-pool=10`
  - 10 VUs: 2278.346783/s 2370.646349/s 2438.656923/s
  - 20 VUs: 2210.673572/s 2295.141009/s 2280.404839/s
  - 30 VUs: 2186.814126/s 2163.264464/s 2207.571604/s
  - 250 VUs: 2099.87669/s 2141.417224/s 2140.806856/s

- `db-pool=20`
  - 10 VUs: 2331.357225/s 2349.574695/s 2456.675875/s
  - 20 VUs: 2395.436695/s 2388.381263/s 2419.07216/s
  - 30 VUs: 2344.574988/s 2350.242068/s 2352.988468/s
  - 250 VUs: 2365.656108/s 2337.760705/s 2238.94388/s

(more VUs leads to errors on this instance)