### PR TITLE
postgrest: k6 tests now need explicit VUs

### DIFF
--- a/postgrest/deploy.nix
+++ b/postgrest/deploy.nix
@@ -120,6 +120,7 @@ in {
               db-anon-role = "postgres"
               db-use-legacy-gucs = false
               db-pool = ${if builtins.stringLength env.pgrstPool == 0 then "20" else env.pgrstPool}
+              db-pool-timeout = 60
 
               ${
                 if env.withNginx && env.withUnixSocket

--- a/postgrest/k6/GETAllEmbed.js
+++ b/postgrest/k6/GETAllEmbed.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/GETSingle.js
+++ b/postgrest/k6/GETSingle.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/GETSingleEmbed.js
+++ b/postgrest/k6/GETSingleEmbed.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/PATCHSingle.js
+++ b/postgrest/k6/PATCHSingle.js
@@ -4,7 +4,6 @@ import { Rate } from 'k6/metrics'
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/POSTBulk.js
+++ b/postgrest/k6/POSTBulk.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/POSTSingle.js
+++ b/postgrest/k6/POSTSingle.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/RPCGETSingle.js
+++ b/postgrest/k6/RPCGETSingle.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/RPCGETSingleEmbed.js
+++ b/postgrest/k6/RPCGETSingleEmbed.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/RPCSimple.js
+++ b/postgrest/k6/RPCSimple.js
@@ -5,7 +5,6 @@ import http from 'k6/http';
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/k6/ReadSchemaPATCHSingle.js
+++ b/postgrest/k6/ReadSchemaPATCHSingle.js
@@ -7,7 +7,6 @@ import { Rate } from 'k6/metrics'
 const URL = "http://pgrst";
 
 export const options = {
-  vus: 10,
   duration: '30s',
   thresholds: {
     'failed requests': ['rate<0.1'],

--- a/postgrest/shell.nix
+++ b/postgrest/shell.nix
@@ -32,9 +32,9 @@ let
     pkgs.writeShellScriptBin "pgrbench-k6"
       ''
         set -euo pipefail
-        filename=$(basename $1 .js)
+        filename=$(basename $2 .js)
 
-        nixops ssh -d pgrbench client k6 run --summary-export=$filename.json - < $1
+        nixops ssh -d pgrbench client k6 run --vus $1 --summary-export=$filename.json - < $2
       '';
   clientPgBench =
     pkgs.writeShellScriptBin "pgrbench-pgbench"
@@ -112,5 +112,6 @@ pkgs.mkShell {
 
     export PGRBENCH_PG_INSTANCE_TYPE="t3a.nano"
     export PGRBENCH_PGRST_INSTANCE_TYPE="t3a.nano"
+    export PGRBENCH_PGRST_POOL="100"
   '';
 }


### PR DESCRIPTION
Corrected the results in this comment https://github.com/supabase/benchmarks/issues/2#issuecomment-1091018069 - which were wrongly using a fixed number of VUs(10) before