### PR TITLE
nginx: Add worker_proccesses and worker_connections entries

### DIFF
--- a/postgrest/deploy.nix
+++ b/postgrest/deploy.nix
@@ -166,7 +166,11 @@ in {
     services.nginx = {
       enable = env.withNginx;
       config = ''
-        events {}
+        worker_processes auto;
+
+        events {
+   	  worker_connections 1024;
+	}
 
         http {
           upstream postgrest {


### PR DESCRIPTION
Adding these two entries improves benchmarking results upto 20% and
also reduces failed requests.

Signed-off-by: Lakshmipathi Ganapathi <lakshmi@supabase.io>
